### PR TITLE
Continue walking DOM nodes after child binding

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -23,7 +23,8 @@ module.exports = function(bindings, view) {
     else if(node.nodeType === 1) {
       var View = bindings.component(node);
       if(View) {
-        return activeBindings.push(new ChildBinding(view, node, View));
+        activeBindings.push(new ChildBinding(view, node, View));
+        return next();
       }
       each(attrs(node), function(attr){
         var binding = bindings.directive(attr);


### PR DESCRIPTION
It would stop walking other nodes after the fist child view element otherwise.

Fixes the example from the docs:

```
<div class="Profile">
  <profile-avatar username="{{username}}"></profile-avatar>
  <profile-link username="{{username}}"></profile-link>
</div>
```
