### PR TITLE
Emit "mounted" event on child views

### DIFF
--- a/lib/child-binding.js
+++ b/lib/child-binding.js
@@ -27,10 +27,12 @@ function ChildBinding(view, node, View) {
   this.child.on('destroyed', this.unbind.bind(this));
   this.view.once('mounted', function() {
     self.view.on('mounted', function() {
+      self.child.emit('mounted');
       View.emit('mounted', self.child);
     });
   });
   this.view.on('unmounted', function() {
+    self.child.emit('unmounted');
     View.emit('unmounted', self.child);
   });
   this.node = this.child.el;

--- a/lib/child-binding.js
+++ b/lib/child-binding.js
@@ -12,6 +12,7 @@ var raf = require('raf-queue');
  * @param {Function} View
  */
 function ChildBinding(view, node, View) {
+  var self = this;
   this.update = this.update.bind(this);
   this.view = view;
   this.attrs = attrs(node);
@@ -24,6 +25,14 @@ function ChildBinding(view, node, View) {
   });
   this.child.replace(node);
   this.child.on('destroyed', this.unbind.bind(this));
+  this.view.once('mounted', function() {
+    self.view.on('mounted', function() {
+      View.emit('mounted', self.child);
+    });
+  });
+  this.view.on('unmounted', function() {
+    View.emit('unmounted', self.child);
+  });
   this.node = this.child.el;
   this.bind();
 }


### PR DESCRIPTION
According to [this](https://github.com/ripplejs/ripple/tree/master/docs#lifecycle-events) documentation, a `mounted` event should be triggered, each time a view enters the DOM.

This implies, that each time a view is mounted, each of its child views (attached via `.compose()`) should emit a `mounted` event as well.

Currently this is not the case. I will look into this (I guess it should be fairly straightforward to implement this) and see if I can provide a pull-request, but for now I wanted to know your opinions of this, and if this would be indeed the correct, expected behavior.

Sorry about issue #30, I would have preferred to attach the PR to it, but apparently I am not quite familiar enough with github to do that. Therefore I closed #30 and continue here.
