### PR TITLE
update markdown example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Supports real browsers and IE9+.
 * [Clock](http://jsfiddle.net/chrisbuttery/QnHPj/3/)
 * [Counter](http://jsfiddle.net/anthonyshort/ybq9Q/light/)
 * [Like Button](http://jsfiddle.net/anthonyshort/ZA2gQ/6/light/)
-* [Markdown Editor](http://jsfiddle.net/anthonyshort/QGK3r/light/)
+* [Markdown Editor](http://jsfiddle.net/QGK3r/40/)
 * [Iteration](http://jsfiddle.net/chrisbuttery/4j5ZD/1/light/)
 
 See more examples at [ripplejs/examples](https://github.com/ripplejs/examples)


### PR DESCRIPTION
I noticed the Markdown Editor example had some bugs in it. First, the external JS pointed to a minified version of ripple on rawgithub that isn't in the current branch. Second, the view was being created with

```
var view = new View({
  data: {
    text: '# title'
  }
});
```

and it seemed like nesting the `text` under `data` was causing the markdown extension to fail. I unnested it and got it working again; was that the best solution?
